### PR TITLE
Update styles for YAML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0
+
+- Improves YAML syntax highlighting with better color differentiation for entities and values.
+
 ## 0.9.0
 
 - Switch publisher to Apollo's official VS Code Marketplace organization (`apollographql`).

--- a/themes/apollo-midnight-color-theme.json
+++ b/themes/apollo-midnight-color-theme.json
@@ -914,6 +914,42 @@
 			}
 		},
 		{
+			"name": "YAML - Entity tag",
+			"scope": [
+				"entity.name.tag.yaml"
+			],
+			"settings": {
+				"foreground": "#CD8FFF", // purple-light
+			}
+		},
+		{
+			"name": "YAML - Single line string & constant value",
+			"scope": [
+				"string.unquoted.plain.out.yaml, constant.numeric.integer.yaml"
+			],
+			"settings": {
+				"foreground": "#E6EBFF", // midnight-lightest
+			}
+		},
+		{
+			"name": "YAML - Block text value",
+			"scope": [
+				"string.unquoted.block.yaml"
+			],
+			"settings": {
+				"foreground": "#B4C3DB", // midnight-lightest
+			}
+		},
+		{
+			"name": "YAML - Boolean value",
+			"scope": [
+				"constant.language.boolean.yaml"
+			],
+			"settings": {
+				"foreground": "#F4D03F", // yellow-base
+			}
+		},
+		{
 			"name": "Markup - Italic",
 			"scope": [
 				"markup.italic"


### PR DESCRIPTION
Improved contrast for YAML files. Previously basically all blue. Now has some actual color structure & contrast.

| Before | After |
|---|---|
|![image](https://user-images.githubusercontent.com/1319791/101971593-5f763a80-3be7-11eb-8fcf-6ef07873a7f5.png)|![image](https://user-images.githubusercontent.com/1319791/101971601-7f0d6300-3be7-11eb-8141-1b433ac4700d.png)|

